### PR TITLE
Fix metadata serialization

### DIFF
--- a/python_hll/serialization.py
+++ b/python_hll/serialization.py
@@ -255,7 +255,7 @@ class BigEndianAscendingWordSerializer:
             aligned_bits = BitUtil.left_shift_long(bits_that_the_byte_can_accept, bits_in_byte_remaining_after_write)
 
             # Update the byte with the alignedBits.
-            self._bytes[self._byte_index] |= BitUtil.to_signed_byte(aligned_bits)
+            self._bytes[self._byte_index] |= aligned_bits
 
             # Update state with bit count written.
             bits_left_in_word -= number_of_bits_to_write

--- a/python_hll/serialization.py
+++ b/python_hll/serialization.py
@@ -622,7 +622,7 @@ class SerializationUtil:
         :returns: the packed version byte
         :rtype: byte
         """
-        return BitUtil.to_signed_byte(BitUtil.left_shift_int(cls.NIBBLE_MASK & schema_version, cls.NIBBLE_BITS) | (cls.NIBBLE_MASK & type_ordinal))
+        return BitUtil.left_shift_int(cls.NIBBLE_MASK & schema_version, cls.NIBBLE_BITS) | (cls.NIBBLE_MASK & type_ordinal)
 
     @classmethod
     def pack_cutoff_byte(cls, explicit_cutoff, sparse_enabled):

--- a/python_hll/serialization.py
+++ b/python_hll/serialization.py
@@ -644,7 +644,7 @@ class SerializationUtil:
         :rtype: byte
         """
         sparse_bit = BitUtil.left_shift_int(1, cls.EXPLICIT_CUTOFF_BITS) if sparse_enabled else 0
-        return BitUtil.to_signed_byte(sparse_bit | (cls.EXPLICIT_CUTOFF_MASK & explicit_cutoff))
+        return sparse_bit | (cls.EXPLICIT_CUTOFF_MASK & explicit_cutoff)
 
     @classmethod
     def pack_parameters_byte(cls, register_width, register_count_log2):
@@ -665,7 +665,7 @@ class SerializationUtil:
         """
         width_bits = (register_width - 1) & cls.REGISTER_WIDTH_MASK
         count_bits = register_count_log2 & cls.LOG2_REGISTER_COUNT_MASK
-        return BitUtil.to_signed_byte(BitUtil.to_signed_byte(BitUtil.left_shift_int(width_bits, cls.LOG2_REGISTER_COUNT_BITS) | count_bits))
+        return BitUtil.left_shift_int(width_bits, cls.LOG2_REGISTER_COUNT_BITS) | count_bits
 
     @classmethod
     def sparse_enabled(cls, cutoff_byte):

--- a/tests/test_hll_serialization.py
+++ b/tests/test_hll_serialization.py
@@ -9,6 +9,7 @@ from copy import deepcopy
 from python_hll.hlltype import HLLType
 from python_hll.hll import HLL
 from python_hll.serialization import SerializationUtil
+from python_hll.util import BitUtil
 
 # A fixed random seed so that this test is reproducible.
 RANDOM_SEED = 1
@@ -19,6 +20,44 @@ def test_parameters_byte():
     assert 5 == SerializationUtil.register_count_log2(0x85)
 
     assert 0x85 == SerializationUtil.pack_parameters_byte(5, 5)
+
+
+def test_parameters_byte_roundtrip():
+    log2m = 5
+    regwidth = 6
+    expthresh = 0
+    sparseon = False
+    input_hll = HLL(log2m, regwidth, expthresh, sparseon)
+
+    output_hll = HLL.from_bytes(input_hll.to_bytes())
+    assert log2m == output_hll._log2m
+    assert regwidth == output_hll._regwidth
+
+
+def test_cutoff_byte_auto():
+    log2m = 5
+    regwidth = 3
+    expthresh = -1
+    sparseon = True
+    input_hll = HLL(log2m, regwidth, expthresh, sparseon)
+
+    output_hll = HLL.from_bytes(input_hll.to_bytes())
+    assert not output_hll._sparse_off
+    assert output_hll._explicit_auto
+    assert not output_hll._explicit_off
+
+
+def test_cutoff_byte_max():
+    log2m = 5
+    regwidth = 3
+    expthresh = 18
+    sparseon = True
+    input_hll = HLL(log2m, regwidth, expthresh, sparseon)
+
+    output_hll = HLL.from_bytes(input_hll.to_bytes())
+    assert not output_hll._sparse_off
+    assert not output_hll._explicit_auto
+    assert not output_hll._explicit_off
 
 
 def test_serialization_smoke(fastonly):

--- a/tests/test_hll_serialization.py
+++ b/tests/test_hll_serialization.py
@@ -8,9 +8,17 @@ import sys
 from copy import deepcopy
 from python_hll.hlltype import HLLType
 from python_hll.hll import HLL
+from python_hll.serialization import SerializationUtil
 
 # A fixed random seed so that this test is reproducible.
 RANDOM_SEED = 1
+
+
+def test_parameters_byte():
+    assert 5 == SerializationUtil.register_width(0x85)
+    assert 5 == SerializationUtil.register_count_log2(0x85)
+
+    assert 0x85 == SerializationUtil.pack_parameters_byte(5, 5)
 
 
 def test_serialization_smoke(fastonly):


### PR DESCRIPTION
I think we're not supposed to call `to_signed_byte` on the outputs when serializing metadata.

When looking at the behaviour of the postgres extension:

```
> SELECT hll_empty(5, 5, 0, 0);
 hll_empty
-----------
 \x118500
```
The parameters byte is 0x85 when log2m=5 and regwidth=5.

See `test_parameters_byte` which fails against master but passes against this PR.

The version byte and cutoff bytes are harder to demonstrate since there are no valid arguments for which their encoded bytes exceeds 127 (where `to_signed_byte` will have an effect), however I think it's better to remove the calls to `to_signed_byte`, since they have no effect.
